### PR TITLE
Updated data grants

### DIFF
--- a/fastlab/content/deep-data-security/data-grants/data-grants.md
+++ b/fastlab/content/deep-data-security/data-grants/data-grants.md
@@ -265,7 +265,7 @@ For the Oracle Deep Data Security data grants, you will continue to use the same
       ```sql
       <copy>
       CREATE OR REPLACE DATA GRANT hr.HRAPP_EMPLOYEES_ACCESS
-        AS SELECT, UPDATE(phone_number)
+        AS SELECT, UPDATE(phone_number, first_name)
         ON hr.employees
         WHERE upper(user_name) = upper(ORA_END_USER_CONTEXT.username)
         TO HRAPP_EMPLOYEES;
@@ -696,4 +696,4 @@ To explore the foundational concepts without an external identity provider — i
 
 ## Acknowledgements
 * **Author** - Roger Wigenstam, Oracle Database Security Product Management, March 2026
-* **Last Updated By/Date** - Richard C. Evans, Oracle Database Security Product Management, April 2026
+* **Last Updated By/Date** - Richard C. Evans, Oracle Database Security Product Management, May 2026

--- a/fastlab/content/deep-data-security/end-user-data-grants/end-user-data-grants.md
+++ b/fastlab/content/deep-data-security/end-user-data-grants/end-user-data-grants.md
@@ -281,7 +281,7 @@ Next, you will ensure that Emma and Marvin can see all of their own data and upd
       ```sql
       <copy>
       CREATE OR REPLACE DATA GRANT hr.HRAPP_EMPLOYEE_ACCESS
-        AS SELECT, UPDATE(phone_number)
+        AS SELECT, UPDATE(phone_number, first_name)
         ON hr.employees
         WHERE upper(user_name) = upper(ORA_END_USER_CONTEXT.username)
         TO HRAPP_EMPLOYEES;
@@ -704,4 +704,4 @@ To see this in action with Microsoft Entra ID, try the next FastLab:
 
 ## Acknowledgements
 * **Author** - Roger Wigenstam, Oracle Database Security Product Management
-* **Last Updated By/Date:** Richard C. Evans - April 2026
+* **Last Updated By/Date** - Richard C. Evans, Oracle Database Security Product Management, May 2026


### PR DESCRIPTION
WID: 12059 & 12060

## Summary
- Adds `first_name` to `UPDATE` clause in `HRAPP_EMPLOYEES_ACCESS` / `HRAPP_EMPLOYEE_ACCESS` data grants
- Removes April 2026 RU temporary notes (requirement no longer needed)
- Updates "Last Updated By/Date" to May 2026

